### PR TITLE
Fix jsPDF font usage in PDF generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -644,7 +644,8 @@
               if (image.description && image.description.trim()) {
                 console.log(`Dodaję opis: "${image.description}"`);
                 pdf.setFontSize(12);
-                pdf.setFont(undefined, 'normal');
+                // Use a defined font to avoid jsPDF errors
+                pdf.setFont('helvetica', 'normal');
                 
                 const lines = pdf.splitTextToSize(image.description.trim(), contentWidth);
                 const textY = margin + finalHeight + 10;


### PR DESCRIPTION
## Summary
- fix invalid font usage when generating the PDF

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686768a4114c8321a5ba5fb48844771d